### PR TITLE
gpu_stats.py now runs properly on the nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ this information is collected per jobid and written to Comment-field of jobinfo 
 ## Deployment
 
 On monsoon we have the gpustats.py code running on each node with a gpu. The
-code will continually update the /tmp/gpustats.json file with gpu usage
-metrics. We appended to our task_epilog.sh script with code from
-./files/epilog.sh.
+code will continually update a file unique to each job within /tmp/gpustats/ for
+each job that uses a gpu. Our task_epilog.sh script sets the job comment to the
+contents of this file, if it exists.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# ansible-role-sacct_gpu
-Add gpu utilization stats to Slurm batch scheduler accounting db. Tested with CentOS-7.
+# gpustats
+Add gpu utilization stats to Slurm batch scheduler accounting db. Tested with CentOS-6.
 
 ## Background
 
@@ -17,4 +17,7 @@ this information is collected per jobid and written to Comment-field of jobinfo 
 
 ## Deployment
 
-Simply apply this ansible-role to your nodes. We are using this together with [OpenHPC](https://openhpc.community/) and use this directly with OHPC-images.
+On monsoon we have the gpustats.py code running on each node with a gpu. The
+code will continually update the /tmp/gpustats.json file with gpu usage
+metrics. We appended to our task_epilog.sh script with code from
+./files/epilog.sh.

--- a/files/gpu_stat.py
+++ b/files/gpu_stat.py
@@ -1,4 +1,4 @@
-#!/packages/python/anaconda3/default/bin/python
+#!/usr/bin/python3
 
 # author mhakala
 import json
@@ -6,14 +6,21 @@ import re
 import subprocess
 import tempfile
 import os
-
+import xml.etree.cElementTree as ET
+import argparse
+import os.path
+import time
+import random
+from datetime import datetime
+from datetime import timedelta
+import traceback
+import configparser
 
 def jobs_running():
    """find slurm-job-ids active on this node"""
    data = subprocess.check_output(['squeue', '-w', os.uname()[1].split('.')[0], '-h', '-o', '%A']).decode()
    return data.split()
-
-
+      
 def pid2id(pid):
    """convert pid to slurm jobid"""
    with open('/proc/%s/cgroup' % pid) as f:
@@ -22,7 +29,6 @@ def pid2id(pid):
          if m:
             return m.group(1)
    return None
-
 
 # get needed slurm values for each running job on the node
 def job_info(jobs,current):
@@ -52,7 +58,6 @@ def job_info(jobs,current):
 
 
 def gpu_info(jobinfo):
-   import xml.etree.cElementTree as ET
 
    output = subprocess.check_output(['nvidia-smi', '-q', '-x']).decode()
    root = ET.fromstring(output)
@@ -69,6 +74,7 @@ def gpu_info(jobinfo):
          # Assume used_memory is of the form '1750 MiB'. Needs fixing
          # if the unit is anything but MiB.
          mtot += float(pi.find('used_memory').text.split()[0])
+
       util = gpu.find('utilization')
       # Here assume gpu utilization is of the form
       # '100 %'
@@ -79,74 +85,93 @@ def gpu_info(jobinfo):
       gpwrdraw = float(power.find('power_draw').text.split()[0])
 
       # only update, if jobid not dropped (multinode jobs)
-      # import pdb; pdb.set_trace()
+      # if a job is using multiple GPUs, code below should execute again
       if jobid in jobinfo.keys():
          if jobinfo[jobid]['ngpu'] != 0:
             jobinfo[jobid]['gpu_util'] += gutil/jobinfo[jobid]['ngpu']
-         jobinfo[jobid]['gpu_power'] += gpwrdraw
-         jobinfo[jobid]['gpu_mem_max'] = max(mtot, jobinfo[jobid]['gpu_mem_max'])
-
+            jobinfo[jobid]['gpu_power'] += gpwrdraw
+            jobinfo[jobid]['gpu_mem_max'] = max(mtot,
+                                                jobinfo[jobid]['gpu_mem_max'])
    return jobinfo
 
 def read_shm(fil):
-   import os.path
    jobinfo = {}
-
    if(os.path.exists(fil)):
       with open(fil) as fp:
          jobinfo=json.loads(fp.read())
 
    return jobinfo
 
-# def write_shm(jobinfo, fname):
-#    with tempfile.NamedTemporaryFile(mode='w', delete=False, \
-#                      dir=os.path.dirname(os.path.normpath(fname))) as fp:
-#       json.dump(jobinfo, fp)
-#    os.chmod(fp.name, 0o0644)
-#    os.rename(fp.name, fname)
-
 def write_shm(jobinfo):
    with open('/tmp/gpustats.json', 'w') as fp:
-      json.dump(jobinfo, fp)   
+      json.dump(jobinfo, fp)
+
+def clean_gpustats(gpustats, max_age):
+   keys_to_delete = []
+   latest = datetime.now() - timedelta(days=max_age)
+   latest = latest.strftime("%Y-%m-%d %H:%M:%S")
+   for key in gpustats:
+      timestamp = gpustats[key]['timestamp']
+      if timestamp < latest:
+         keys_to_delete.append(key)
+   for key in keys_to_delete:
+      del gpustats[key]
+   return gpustats
 
 def main():
-   import argparse
    parser = argparse.ArgumentParser()
    parser.add_argument('-n', '--nosleep', help="Don't sleep at the beginning",
                        action="store_true")
    parser.add_argument('fname', nargs='?', default='/tmp/gpustats.json',
                        help='Name of JSON file for reading/storing data')
+   parser.add_argument('-l', '--logfile',
+                       help="Name of log file where any exceptions will be written to",
+                       default='/tmp/gpustats.log')
+   parser.add_argument('-m', '--max-age', type=int, default=7,
+                       help='The maximum time (in days) for which the gpu stats of a job will be stored')
    args = parser.parse_args()
-   if not args.nosleep:
-      import time
-      import random
-      time.sleep(random.randint(0, 30))
 
-   # initialize stats
-   current = {}
-   jobs    = jobs_running()
+   logfile = open(args.logfile, 'a+')
 
-   for job in jobs:
-      current[job]={'gpu_util': 0, 'gpu_mem_max': 0, 'ngpu': 0, 'ncpu': 0, 'step': 1, 'gpu_power': 0 }
+   try:
+      if not args.nosleep:
+         time.sleep(random.randint(0, 30))
 
-   # get current job info
-   current = job_info(jobs, current)
-   current = gpu_info(current)
+      # initialize stats
+      current = {}
+      jobs    = jobs_running()
 
-   # combine with previous steps, calculate avgs and max
-   prev = read_shm(args.fname)
-   for job in jobs:
-      if job in prev.keys():
-         n = prev[job]['step']
-         current[job]['gpu_util'] = ( float(prev[job]['gpu_util'])*n+float(current[job]['gpu_util']) )/(n+1)
-         current[job]['gpu_power'] = ( float(prev[job]['gpu_power'])*n+float(current[job]['gpu_power']) )/(n+1)
-         current[job]['gpu_mem_max']  = max(float(prev[job]['gpu_mem_max']), float(current[job]['gpu_mem_max']))
-         current[job]['step'] = n+1
+      for job in jobs:
+         current[job]={'gpu_util': 0, 'gpu_mem_max': 0, 'ngpu': 0,
+                       'ncpu': 0, 'step': 1, 'gpu_power': 0 ,
+                       'timestamp':
+                       datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
 
-   # write json
-   write_shm(current)
+      # get current job info
+      current = job_info(jobs, current)
+      current = gpu_info(current)
 
+      # combine with previous steps, calculate avgs and max
+      prev = read_shm(args.fname)
+      for job in jobs:
+         if job in prev.keys():
+            n = prev[job]['step']
+            current[job]['gpu_util'] = ( float(prev[job]['gpu_util'])*n+float(current[job]['gpu_util']) )/(n+1)
+            current[job]['gpu_power'] = ( float(prev[job]['gpu_power'])*n+float(current[job]['gpu_power']) )/(n+1)
+            current[job]['gpu_mem_max']  = max(float(prev[job]['gpu_mem_max']), float(current[job]['gpu_mem_max']))
+            current[job]['step'] = n+1
+
+      for job in prev.keys():
+         # if it's a job that is no longer running, save it's stats anyway
+         if job not in jobs:
+            current[job] = prev[job]
+
+      # write json
+      current = clean_gpustats(current, args.max_age)
+      write_shm(current)
+
+   except Exception as e:
+      logfile.write(traceback.format_exc())
 
 if __name__ == '__main__':
-    main()
-
+   main()

--- a/files/gpu_stat.py
+++ b/files/gpu_stat.py
@@ -15,163 +15,191 @@ from datetime import datetime
 from datetime import timedelta
 import traceback
 import configparser
+import glob
 
 def jobs_running():
-   """find slurm-job-ids active on this node"""
-   data = subprocess.check_output(['squeue', '-w', os.uname()[1].split('.')[0], '-h', '-o', '%A']).decode()
-   return data.split()
-      
+    """find slurm-job-ids active on this node"""
+    data = subprocess.check_output(['squeue', '-w', os.uname()[1].split('.')[0], '-h', '-o', '%A']).decode()
+    return data.split()
+
 def pid2id(pid):
-   """convert pid to slurm jobid"""
-   with open('/proc/%s/cgroup' % pid) as f:
-      for line in f:
-         m = re.search('.*slurm\/uid_.*\/job_(\d+)\/.*', line)
-         if m:
-            return m.group(1)
-   return None
+    """convert pid to slurm jobid"""
+    with open('/proc/%s/cgroup' % pid) as f:
+        for line in f:
+            m = re.search('.*slurm\/uid_.*\/job_(\d+)\/.*', line)
+            if m:
+                return m.group(1)
+    return None
 
 # get needed slurm values for each running job on the node
 def job_info(jobs,current):
-   for job in jobs:
-      output = subprocess.check_output(['scontrol', '-o', 'show', 'job', job]).decode()
-      cpus   = re.search('NumCPUs=(\d+)', output)
-      tres   = re.search('TRES=(\S+)', output).group(1)
-      nodes  = re.search('NumNodes=(\d+)', output)
+    for job in jobs:
+        output = subprocess.check_output(['scontrol', '-o', 'show', 'job', job]).decode()
+        cpus   = re.search('NumCPUs=(\d+)', output)
+        tres   = re.search('TRES=(\S+)', output).group(1)
+        nodes  = re.search('NumNodes=(\d+)', output)
 
-      ngpu = 0
-      for g in tres.split(','):
-         gs = g.split('=')
-         if gs[0] == 'gres/gpu:tesla':
-            if len(gs) == 1:
-               ngpu = 1
-            else:
-               ngpu = int(gs[-1])
+        ngpu = 0
+        for g in tres.split(','):
+            gs = g.split('=')
+            if gs[0] == 'gres/gpu:tesla':
+                if len(gs) == 1:
+                    ngpu = 1
+                else:
+                    ngpu = int(gs[-1])
 
-      # drop multi-node jobs (will be added later if needed)
-      if int(nodes.group(1)) > 1:
-         del current[job]
-      else:
-         current[job]['ngpu'] = ngpu
-         current[job]['ncpu']=int(cpus.group(1))
+        # drop multi-node jobs (will be added later if needed)
+        if int(nodes.group(1)) > 1:
+            del current[job]
+        else:
+            current[job]['ngpu'] = ngpu
+            current[job]['ncpu']=int(cpus.group(1))
 
-   return current
+    return current
 
 
 def gpu_info(jobinfo):
 
-   output = subprocess.check_output(['nvidia-smi', '-q', '-x']).decode()
-   root = ET.fromstring(output)
+    output = subprocess.check_output(['nvidia-smi', '-q', '-x']).decode()
+    root = ET.fromstring(output)
 
-   for gpu in root.findall('gpu'):
-      procs = gpu.find('processes')
-      mtot = 0.
-      jobid = None
-      # Here we assume that multiple job id's cannot access the same
-      # GPU
-      for pi in procs.findall('process_info'):
-         pid = pi.find('pid').text
-         jobid = pid2id(pid)
-         # Assume used_memory is of the form '1750 MiB'. Needs fixing
-         # if the unit is anything but MiB.
-         mtot += float(pi.find('used_memory').text.split()[0])
+    for gpu in root.findall('gpu'):
+        procs = gpu.find('processes')
+        mtot = 0.
+        jobid = None
+        # Here we assume that multiple job id's cannot access the same
+        # GPU
+        for pi in procs.findall('process_info'):
+            pid = pi.find('pid').text
+            jobid = pid2id(pid)
+            # Assume used_memory is of the form '1750 MiB'. Needs fixing
+            # if the unit is anything but MiB.
+            mtot += float(pi.find('used_memory').text.split()[0])
 
-      util = gpu.find('utilization')
-      # Here assume gpu utilization is of the form
-      # '100 %'
-      gutil = float(util.find('gpu_util').text.split()[0])
+        util = gpu.find('utilization')
+        # Here assume gpu utilization is of the form
+        # '100 %'
+        gutil = float(util.find('gpu_util').text.split()[0])
 
-      # power_draw is of the form 35.25 W
-      power = gpu.find('power_readings')
-      gpwrdraw = float(power.find('power_draw').text.split()[0])
+        # power_draw is of the form 35.25 W
+        power = gpu.find('power_readings')
+        gpwrdraw = float(power.find('power_draw').text.split()[0])
 
-      # only update, if jobid not dropped (multinode jobs)
-      # if a job is using multiple GPUs, code below should execute again
-      if jobid in jobinfo.keys():
-         if jobinfo[jobid]['ngpu'] != 0:
-            jobinfo[jobid]['gpu_util'] += gutil/jobinfo[jobid]['ngpu']
-            jobinfo[jobid]['gpu_power'] += gpwrdraw
-            jobinfo[jobid]['gpu_mem_max'] = max(mtot,
-                                                jobinfo[jobid]['gpu_mem_max'])
-   return jobinfo
+        # only update, if jobid not dropped (multinode jobs)
+        # if a job is using multiple GPUs, code below should execute again
+        if jobid in jobinfo.keys():
+            if jobinfo[jobid]['ngpu'] != 0:
+                jobinfo[jobid]['gpu_util'] += gutil/jobinfo[jobid]['ngpu']
+                jobinfo[jobid]['gpu_power'] += gpwrdraw
+                jobinfo[jobid]['gpu_mem_max'] = max(mtot,
+                                                    jobinfo[jobid]['gpu_mem_max'])
+    return jobinfo
 
-def read_shm(fil):
-   jobinfo = {}
-   if(os.path.exists(fil)):
-      with open(fil) as fp:
-         jobinfo=json.loads(fp.read())
+def read_shm(dir_name):
+    jobinfo = {}
+    for fpath in glob.glob(dir_name + '*.json'):
+        jobid = fpath.replace(dir_name, '').replace('.json', '')
+        with open(fpath, 'r') as fp:
+            jobinfo[jobid] = json.loads(fp.read())
+    return jobinfo
 
-   return jobinfo
+def write_shm(jobinfo, running_jobids, dir_path, max_age):
+    latest = datetime.now() - timedelta(days=max_age)
+    latest = latest.strftime("%Y-%m-%d %H:%M:%S")
 
-def write_shm(jobinfo):
-   with open('/tmp/gpustats.json', 'w') as fp:
-      json.dump(jobinfo, fp)
+    for jobid in jobinfo:
+        fpath = dir_path + str(jobid) + '.json'
+        if jobid in running_jobids and jobinfo[jobid]['ngpu'] != 0:
+            with open(fpath, 'w') as fp:
+                json.dump(jobinfo[jobid], fp)
+        elif jobinfo[jobid]['timestamp'] < latest:
+            os.remove(fpath)
 
-def clean_gpustats(gpustats, max_age):
-   keys_to_delete = []
-   latest = datetime.now() - timedelta(days=max_age)
-   latest = latest.strftime("%Y-%m-%d %H:%M:%S")
-   for key in gpustats:
-      timestamp = gpustats[key]['timestamp']
-      if timestamp < latest:
-         keys_to_delete.append(key)
-   for key in keys_to_delete:
-      del gpustats[key]
-   return gpustats
+def dir_path(path):
+    if os.path.isdir(path):
+        return path
+    else:
+        raise argparse.ArgumentTypeError("readable_dir:" +
+                                         str(path) +
+                                         " is not a valid path")
 
 def main():
-   parser = argparse.ArgumentParser()
-   parser.add_argument('-n', '--nosleep', help="Don't sleep at the beginning",
-                       action="store_true")
-   parser.add_argument('fname', nargs='?', default='/tmp/gpustats.json',
-                       help='Name of JSON file for reading/storing data')
-   parser.add_argument('-l', '--logfile',
-                       help="Name of log file where any exceptions will be written to",
-                       default='/tmp/gpustats.log')
-   parser.add_argument('-m', '--max-age', type=int, default=7,
-                       help='The maximum time (in days) for which the gpu stats of a job will be stored')
-   args = parser.parse_args()
+    start_time = time.time()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('dir_path',
+                        type=dir_path,
+                        nargs='?',
+                        default='/tmp/gpu_stats/',
+                        help="The directory where a JSON for each job is stored")
+    parser.add_argument('-n', '--nosleep',
+                        help="Don't sleep at the beginning",
+                        action="store_true")    
+    parser.add_argument('-l',
+                        '--logfile',
+                        help="Name of log file where any exceptions will be written to",
+                        default='/tmp/gpustats.log')
+    parser.add_argument('-m',
+                        '--max-age',
+                        type=int,
+                        default=1,
+                        help='The maximum time (in days) for which the gpu stats of a job will be stored')
+    args = parser.parse_args()
 
-   logfile = open(args.logfile, 'a+')
+    if args.dir_path[-1] != '/':
+        args.dir_path += '/'
 
-   try:
-      if not args.nosleep:
-         time.sleep(random.randint(0, 30))
+    logfile = open(args.logfile, 'a+')
 
-      # initialize stats
-      current = {}
-      jobs    = jobs_running()
+    try:
+        if not args.nosleep:
+            time.sleep(random.randint(0, 30))
 
-      for job in jobs:
-         current[job]={'gpu_util': 0, 'gpu_mem_max': 0, 'ngpu': 0,
-                       'ncpu': 0, 'step': 1, 'gpu_power': 0 ,
-                       'timestamp':
-                       datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+        # initialize stats
+        current = {}
+        jobs    = jobs_running()
 
-      # get current job info
-      current = job_info(jobs, current)
-      current = gpu_info(current)
+        for job in jobs:
+            current[job]={'gpu_util': 0, 'gpu_mem_max': 0, 'ngpu': 0,
+                          'ncpu': 0, 'step': 1, 'gpu_power': 0,
+                          'timestamp':
+                          datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
 
-      # combine with previous steps, calculate avgs and max
-      prev = read_shm(args.fname)
-      for job in jobs:
-         if job in prev.keys():
-            n = prev[job]['step']
-            current[job]['gpu_util'] = ( float(prev[job]['gpu_util'])*n+float(current[job]['gpu_util']) )/(n+1)
-            current[job]['gpu_power'] = ( float(prev[job]['gpu_power'])*n+float(current[job]['gpu_power']) )/(n+1)
-            current[job]['gpu_mem_max']  = max(float(prev[job]['gpu_mem_max']), float(current[job]['gpu_mem_max']))
-            current[job]['step'] = n+1
+        # get current job info
+        current = job_info(jobs, current)
+        current = gpu_info(current)
 
-      for job in prev.keys():
-         # if it's a job that is no longer running, save it's stats anyway
-         if job not in jobs:
-            current[job] = prev[job]
+        # running_jobids contains jobids of jobs that are running
+        # if a jobid is not in this set,
+        # then we don't need to write to the corresponding file
+        running_jobids = set(current.keys())
 
-      # write json
-      current = clean_gpustats(current, args.max_age)
-      write_shm(current)
+        # combine with previous steps, calculate avgs and max
+        prev = read_shm(args.dir_path)
 
-   except Exception as e:
-      logfile.write(traceback.format_exc())
+        for job in jobs:
+            if job in prev.keys():
+                n = prev[job]['step']
+                current[job]['gpu_util'] = ( float(prev[job]['gpu_util'])*n+float(current[job]['gpu_util']) )/(n+1)
+                current[job]['gpu_power'] = ( float(prev[job]['gpu_power'])*n+float(current[job]['gpu_power']) )/(n+1)
+                current[job]['gpu_mem_max']  = max(float(prev[job]['gpu_mem_max']), float(current[job]['gpu_mem_max']))
+                current[job]['step'] = n+1
+
+        for job in prev.keys():
+            if job not in jobs:
+                # it must be a job that is no longer running
+                current[job] = prev[job]
+
+        # write json
+        write_shm(current, running_jobids, args.dir_path, args.max_age)
+
+    except Exception as e:
+        logfile.write(traceback.format_exc())
+
+    end_time = time.time()
+    if end_time - start_time > 55.0:
+        logfile.write("WARNING: runtime was longer than expected at " +
+                      str(end_time - start_time) +
+                      " seconds\n")
 
 if __name__ == '__main__':
-   main()
+    main()

--- a/files/jobinfo.py
+++ b/files/jobinfo.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+#
+# This script loads the gpu stats json and prints the output
+#
+
+import sys
+import json
+
+def getstats(fname):
+    with open(fname) as stats_file:
+        return json.load(stats_file)
+
+if __name__ == '__main__':
+    gpu_stats = getstats(sys.argv[1])
+    job_id = sys.argv[2]
+    if job_id in gpu_stats:
+        print(json.dumps(gpu_stats[job_id]))
+


### PR DESCRIPTION
I've tested it with a watch command. The JSON file will look like this:

{"30493870": {"gpu_util": 63.89423076923076, "gpu_mem_max": 11005.0, "ngpu": 1, "ncpu": 1, "step": 104, "gpu_power": 120.77999999999999}, "30443189": {"gpu_util ": 41.53846153846154, "gpu_mem_max": 11005.0, "ngpu": 1, "ncpu": 1, "step": 104, "gpu_power": 104.41201923076923}}

Multiplying the gpu_util and step fields will give us a number proportional to "gpu hours". The indices in these JSON arrays are JobID values.

Made additional changes, including week-long retention of gpu stats within /tmp/gpustats.json.